### PR TITLE
Fix votes API to track real vote totals

### DIFF
--- a/src/__tests__/artwork.test.ts
+++ b/src/__tests__/artwork.test.ts
@@ -84,6 +84,12 @@ describe('Artwork API Tests', () => {
     expect(res.statusCode).toBe(200);
   });
 
+  test('GET /api/votes - should return total votes', async () => {
+    const res = await request(app).get('/api/votes');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('votes', 1);
+  });
+
   test('DELETE /api/artworks/:artworkSk - should delete artwork', async () => {
     //testArtworkSk = '123e4567-e89b-12d3-a456-426614174000'
 

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -1,4 +1,10 @@
-import { VoteModel } from '../models/votes'; 
+// Use the vote count maintained within the ArtworkModel. The previous
+// implementation relied on VoteModel which was never updated when
+// artworks received votes, causing `/api/votes` to always return `0`.
+// To reflect the real number of votes we read the value from
+// `ArtworkModel.getTotalVotes`.
+import { VoteModel } from '../models/votes';
+import { ArtworkModel } from '../models/artwork';
 
 type GetTotalVotesResult = {
   Item?: { votes: number };
@@ -6,7 +12,9 @@ type GetTotalVotesResult = {
 
 export class VotesService {
   static async getTotalVotes(): Promise<{ votes: number }> {
-    const result: GetTotalVotesResult = await VoteModel.getTotalVotes();
+    // Retrieve the accumulated votes from the artwork model which is updated
+    // whenever a user votes. This ensures the total reflects all user actions.
+    const result: GetTotalVotesResult = await ArtworkModel.getTotalVotes();
     const votes = result.Item?.votes ?? 0;
     return { votes };
   }


### PR DESCRIPTION
## Summary
- fix VotesService to use ArtworkModel for global vote count
- verify total votes via new test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af202936c8326ab85d187777d6d01